### PR TITLE
Fix error in create-json.py (and nucleophilic replacement set) where first ligand was skipped

### DIFF
--- a/synthetic-enumeration/create-json.py
+++ b/synthetic-enumeration/create-json.py
@@ -69,7 +69,7 @@ for series in ligand_dict:
             if forwards:
                 master_dict[index] = {
                     'JOBID':index,
-                    'directory':f'RUN{index-1}',
+                    'directory':f'RUN{index}',
                     'series':series,
 
                     'target':'SARS-CoV-2 Mpro',


### PR DESCRIPTION
My `create-json.py` script erroneously created the first indexed transformation (0) with the `directory` attribute `RUN-1` instead of `RUN0`, causing the first transformation to be skipped.

This PR corrects the script and manually adds the best-docked ligand in the nucleophilic replacement set to the end of the list.